### PR TITLE
reset stdin or something

### DIFF
--- a/mpd-8tracks.py
+++ b/mpd-8tracks.py
@@ -117,10 +117,8 @@ for mix_url in mix_urls:
 
    # Asks if want to download songs
    while True:
-      try:
-         ans = raw_input("Download this playlist? [yn]\n> ")
-      except EOFError:
-         continue
+      sys.stdin = open('/dev/tty')
+      ans = raw_input("Download this playlist? [yn]\n> ")
 
       if (ans[0] == 'y'):
          for track_url, artist, name in infos:


### PR DESCRIPTION
when raw_input receives an EOF (from initially passing in an API key), this makes the second question loop forever and ever and ever (with the EOFError)

this fixes that much anyway, could probably wrap the calls to do this every time
